### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -3,7 +3,6 @@ title = "Software Engineering Study Guide"
 description = "A study guide for software engineering interviews"
 authors = ["Austin Schwarm"]
 language = "en"
-multilingual = false
 src = "src"
 
 [output.html]


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10